### PR TITLE
前回のZipを利用して更新してしまっている問題の修正

### DIFF
--- a/DotnetArchive/ArchiveCommand.cs
+++ b/DotnetArchive/ArchiveCommand.cs
@@ -32,6 +32,10 @@ namespace DotnetArchive
             var options = 0 + (ignoreCase ? GlobOptions.CaseInsensitive : 0);
 
             var files = Glob.Files(Environment.CurrentDirectory, inputPattern, options).ToArray();
+            if(File.Exists(output))
+            {
+                File.Delete(output);
+            }
 
             using var zip = ZipFile.Open(output, ZipArchiveMode.Update);
             long skipCount = 0;


### PR DESCRIPTION
## 概要
`ZipArchive.Open`で以前のZipにそのまま要素が追加されてしまっている問題を修正する