### PR TITLE
Zipを一時領域で生成する & CI条件調整

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,12 +28,14 @@ jobs:
       run: |
         dotnet format DotnetArchive.sln --check
         dotnet format DotnetArchive.sln --check --fix-style warn
-    - name: Build Debug
-      run: dotnet build --no-restore -c Debug
-    - name: Build Release
-      run: dotnet build --no-restore -c Release
+    - name: Build
+      run: |
+        dotnet build --no-restore -c Debug
+        dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: |
+        dotnet test --no-build --verbosity normal --framework netcoreapp3.1
+        dotnet test --no-build --verbosity normal --framework net5.0
     - name: Pack
       run: dotnet pack --no-restore -c Release
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: .NET Publish
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*'
 
@@ -28,7 +30,7 @@ jobs:
     - name: Build Release
       run: dotnet build --no-restore -c Release -p:Version=${GITHUB_REF/refs\/tags\/v/}
     - name: Pack
-      run: dotnet pack --include-symbols --no-restore -c Release --no-build --output nupkg -p:PackageVersion=${GITHUB_REF/refs\/tags\/v/}-alpha
+      run: dotnet pack --no-restore -c Release --no-build --output nupkg -p:PackageVersion=${GITHUB_REF/refs\/tags\/v/}-alpha
     - name: Publish Nuget
       run: dotnet nuget push nupkg/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
     - uses: actions/upload-artifact@v2

--- a/DotnetArchive/DisposableFile.cs
+++ b/DotnetArchive/DisposableFile.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+
+namespace DotnetArchive
+{
+    public class DisposableFile : IDisposable
+    {
+        public string fullFilePath { get; set; } = string.Empty;
+        public bool allowNotFound { get; set; } = false;
+
+        private DisposableFile() { }
+
+        /// <summary>
+        /// create new file
+        /// file will delete when exist
+        /// </summary>
+        public static DisposableFile CreateNew(string fileName, bool allowNotFound = false)
+        {
+            var fullPath = Path.Combine(Environment.CurrentDirectory, fileName);
+            if(File.Exists(fullPath))
+                File.Delete(fullPath);
+
+            using var stream = File.CreateText(fullPath);
+            var instance = new DisposableFile()
+            {
+                fullFilePath = fullPath,
+                allowNotFound = allowNotFound,
+            };
+            return instance;
+        }
+
+        /// <summary>
+        /// open exist file
+        /// file will create when not exist
+        /// </summary>
+        public static DisposableFile OpenOrCreate(string fileName, bool allowNotFound = false)
+        {
+            var fullPath = Path.Combine(Environment.CurrentDirectory, fileName);
+            if(File.Exists(fullPath))
+                File.Delete(fullPath);
+
+            using var stream = File.CreateText(fullPath);
+            var instance = new DisposableFile()
+            {
+                fullFilePath = fullPath,
+                allowNotFound = allowNotFound,
+            };
+            return instance;
+        }
+
+        public void Dispose()
+        {
+            if(File.Exists(this.fullFilePath))
+                File.Delete(this.fullFilePath);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Zipを圧縮対象として指定される可能性のあるディレクトリではなく一時領域で生成するように
また、publishのトリガーをmasterへのpushのみに制限し、dotnet core 3.1と 5.0のテストを明示的に呼び出すように