### PR TITLE
不要なチェックを削除 / DisposableFileの機能していないフラグを実装

### DIFF
--- a/DotnetArchive/Archives/DefaultZipArchive.cs
+++ b/DotnetArchive/Archives/DefaultZipArchive.cs
@@ -29,7 +29,6 @@ namespace DotnetArchive.Archives
 
             var tmpFilePath = Path.Combine(Path.GetTempPath(), "tmp.zip");
             long processedCount = 0;
-            long skipCount = 0;
             using var temporaryFile = DisposableFile.OpenOrCreate(tmpFilePath, true);
             using(var zip = ZipFile.Open(tmpFilePath, ZipArchiveMode.Update))
             {
@@ -37,12 +36,6 @@ namespace DotnetArchive.Archives
                 foreach(var item in files)
                 {
                     var file = Path.Combine(input, item);
-                    if(Path.GetRelativePath(file, output) == ".")
-                    {
-                        skipCount++;
-                        this.logger.ZLogWarning("[Skip] {0} using by other process.", item);
-                        continue;
-                    }
                     zip.CreateEntryFromFile(file, item);
                     processedCount++;
                     this.logger.ZLog(defaultLogLevel, item);
@@ -52,7 +45,7 @@ namespace DotnetArchive.Archives
 
             this.logger.ZLog(defaultLogLevel, " ");
             this.logger.ZLog(defaultLogLevel, "All file archived.");
-            this.logger.ZLog(defaultLogLevel, "Processed: {0} Skip: {1}", processedCount, skipCount);
+            this.logger.ZLog(defaultLogLevel, "Processed: {0} Skip: {1}", processedCount);
             return Task.CompletedTask;
 
         }

--- a/DotnetArchive/Archives/DefaultZipArchive.cs
+++ b/DotnetArchive/Archives/DefaultZipArchive.cs
@@ -45,7 +45,7 @@ namespace DotnetArchive.Archives
 
             this.logger.ZLog(defaultLogLevel, " ");
             this.logger.ZLog(defaultLogLevel, "All file archived.");
-            this.logger.ZLog(defaultLogLevel, "Processed: {0} Skip: {1}", processedCount);
+            this.logger.ZLog(defaultLogLevel, "Processed: {0}", processedCount);
             return Task.CompletedTask;
 
         }

--- a/DotnetArchive/DisposableFile.cs
+++ b/DotnetArchive/DisposableFile.cs
@@ -50,8 +50,13 @@ namespace DotnetArchive
 
         public void Dispose()
         {
+            if(this.allowNotFound && File.Exists(this.fullFilePath) == false)
+                return;
+
             if(File.Exists(this.fullFilePath))
                 File.Delete(this.fullFilePath);
+            // File already disposed
+            else throw new FileNotFoundException(this.fullFilePath);
         }
     }
 }

--- a/DotnetArchive_Test/DisposableFileTest.cs
+++ b/DotnetArchive_Test/DisposableFileTest.cs
@@ -1,0 +1,72 @@
+﻿
+using DotnetArchive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace DotnetArchive_Test
+{
+    [TestClass]
+    public class DisposableFileTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            Directory.CreateDirectory("Test");
+            using var file1 = File.CreateText("Test/A1");
+            using var file2 = File.CreateText("Test/A2");
+        }
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Directory.Delete("Test", true);
+        }
+
+        [TestMethod]
+        public void _ファイルが正しく生成_削除される()
+        {
+            using(var file = DisposableFile.CreateNew("Test/B"))
+            {
+                Assert.IsTrue(File.Exists("Test/B"));
+            }
+            Assert.IsFalse(File.Exists("Test/B"));
+        }
+
+        [TestMethod]
+        public void _ファイルが正しくオープン_削除される()
+        {
+            using(var file = DisposableFile.OpenOrCreate("Test/A1"))
+            {
+                Assert.IsTrue(File.Exists("Test/A1"));
+            }
+            Assert.IsFalse(File.Exists("Test/A1"));
+        }
+
+        [TestMethod]
+        public void _ファイルが削除済みの場合にallowNotFoundが機能する()
+        {
+            // CreateNew_Exception
+            var f1 = DisposableFile.CreateNew("Test/B");
+            File.Delete(f1.fullFilePath);
+
+            Assert.ThrowsException<FileNotFoundException>(() => f1.Dispose());
+
+            // CreateNew_NoError
+            using(var f2 = DisposableFile.CreateNew("Test/B", true))
+            {
+                File.Delete(f2.fullFilePath);
+            }
+
+            // Open_Exception
+            var f3 = DisposableFile.OpenOrCreate("Test/A1");
+            File.Delete(f3.fullFilePath);
+
+            Assert.ThrowsException<FileNotFoundException>(() => f3.Dispose());
+
+            // Open_NoError
+            using(var f4 = DisposableFile.OpenOrCreate("Test/A2", true))
+            {
+                File.Delete(f4.fullFilePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Zip時に自分自身を圧縮する際のチェックが #6 により不要になったので削除する
また、DisposableFIleの`allowNotFound`フラグを機能するように調整 及びテストを作成する