### PR TITLE
ファイル属性値をNormalに設定する

### DIFF
--- a/DotnetArchive/Archives/DefaultArchiveProcessor.cs
+++ b/DotnetArchive/Archives/DefaultArchiveProcessor.cs
@@ -25,6 +25,7 @@ namespace DotnetArchive.Archives
             var file = this.archiver.Archive(input, files, this.logger, quiet);
 
             File.Move(file.fullFilePath, output);
+            File.SetAttributes(output, FileAttributes.Normal);
             file.allowNotFound = true;
             file.Dispose();
         }
@@ -36,6 +37,7 @@ namespace DotnetArchive.Archives
             var file = await this.archiver.ArchiveAsync(input, files, this.logger, quiet, token);
 
             File.Move(file.fullFilePath, output);
+            File.SetAttributes(output, FileAttributes.Normal);
             file.allowNotFound = true;
             file.Dispose();
         }

--- a/DotnetArchive/DotnetArchive.csproj
+++ b/DotnetArchive/DotnetArchive.csproj
@@ -20,10 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConsoleAppFramework" Version="3.2.0" />
+    <PackageReference Include="ConsoleAppFramework" Version="3.3.0" />
     <PackageReference Include="Glob" Version="1.1.8" />
-    <PackageReference Include="ZLogger" Version="1.4.1" />
-    <PackageReference Include="ZString" Version="2.3.1" />
+    <PackageReference Include="ZLogger" Version="1.5.0" />
+    <PackageReference Include="ZString" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotnetArchive_Test/ZipArchiveTest.cs
+++ b/DotnetArchive_Test/ZipArchiveTest.cs
@@ -158,5 +158,15 @@ namespace DotnetArchive_Test
             await archiver.UnArchiveAsync("output.zip", "Test/Output/", false, null, false);
 
         }
+
+        [TestMethod]
+        public async Task _FileAttributeが適切()
+        {
+            var archiver = new DefaultZipArchiver(archiveLog);
+            var archive = new DefaultArchiveProcessor(archiver, processorLog);
+
+            await archive.ArchiveAsync("Test", "**/*", "", "output.zip", false, false, false);
+            Assert.AreEqual(File.GetAttributes("output.zip"), FileAttributes.Normal);
+        }
     }
 }


### PR DESCRIPTION
## 概要
Zip時にファイル属性が`Archive`になっており、いくつかの操作が正しく動かない場合があったので`Normal`に指定する
